### PR TITLE
#5 cross_entropy_error関数の実装

### DIFF
--- a/nn/modules/utils.py
+++ b/nn/modules/utils.py
@@ -45,3 +45,16 @@ def softmax(x: np.ndarray):
     c = np.max(x)
     exp_x = np.exp(x - c)
     return exp_x / np.sum(exp_x)
+
+def cross_entropy_error(y, t):
+  if y.ndim == 1:
+    t = t.reshape(-1, t.size)
+    y = y.reshape(-1, y.size)
+  
+  if t.size == y.size:
+    t = t.argmax(axis=1)
+  
+  batch_size = y.shape[0]
+  delta = delta = 1e-7
+
+  return -np.sum(np.log(y[np.arange(batch_size), t] + delta)) / batch_size


### PR DESCRIPTION
# issue番号
#5 

# 実装の内容
one-hotラベルと整数ラベルの両方に対応した交差エントロピー誤差関数を実装